### PR TITLE
修改问题清单：2创建nfs存储，没有过滤dorado v3设备

### DIFF
--- a/dmestore-service/src/main/java/com/huawei/dmestore/mvc/DmeStorageController.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/mvc/DmeStorageController.java
@@ -35,9 +35,9 @@ public class DmeStorageController extends BaseController {
      * @return ResponseBodyBean
      */
     @GetMapping("/storages")
-    public ResponseBodyBean getStorages() {
+    public ResponseBodyBean getStorages(@RequestParam(defaultValue = "") String flag) {
         try {
-            return success(dmeStorageService.getStorages());
+            return success(dmeStorageService.getStorages(flag));
         } catch (DmeException e) {
             return failure(e.getMessage());
         }
@@ -99,9 +99,10 @@ public class DmeStorageController extends BaseController {
     @GetMapping("/logicports")
     @ResponseBody
     public ResponseBodyBean getLogicPorts(@RequestParam(name = "storageId") String storageId,
+                                          @RequestParam(name = "flag" ,defaultValue = "") String flag,
                                           @RequestParam(name = "supportProtocol",required = false,defaultValue = "all") String supportProtocol) {
         try {
-            return success(dmeStorageService.getLogicPorts(storageId,supportProtocol));
+            return success(dmeStorageService.getLogicPorts(storageId,supportProtocol,flag));
         } catch (DmeException e) {
             return failure(e.getMessage());
         }

--- a/dmestore-service/src/main/java/com/huawei/dmestore/mvc/NfsAccessController.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/mvc/NfsAccessController.java
@@ -93,7 +93,7 @@ public class NfsAccessController extends BaseController {
         try {
             dmeNfsAccessService.mountNfs(params);
             return success(null, "Mount nfs success");
-        } catch (DmeException e) {
+        } catch (Exception e) {
             LOG.error("mount nfs failure:", e);
             failureStr = "mount nfs failure:" + e.toString();
         }

--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeNFSAccessServiceImpl.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeNFSAccessServiceImpl.java
@@ -297,7 +297,7 @@ public class DmeNFSAccessServiceImpl implements DmeNFSAccessService {
         LOG.info("vmware list nfs success!");
 
         // 将DME的存储设备集合转换为map key:ip value:Storage
-        List<Storage> storages = dmeStorageService.getStorages();
+        List<Storage> storages = dmeStorageService.getStorages(null);
         Map<String, Storage> storageMap = converStorage(storages);
         if (storageMap == null || storageMap.size() == 0) {
             LOG.error("get dme storage failed!storages is null!");
@@ -1052,7 +1052,7 @@ public class DmeNFSAccessServiceImpl implements DmeNFSAccessService {
         LOG.info("dme delete nfs end!");
     }
 
-    private void unmountNfsFromHost(String dataStoreObjectId, String hostId) throws VcenterException {
+    private void unmountNfsFromHost(String dataStoreObjectId, String hostId) throws DmeException {
         vcsdkUtils.unmountNfsOnHost(dataStoreObjectId, hostId);
     }
 

--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeStorageService.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeStorageService.java
@@ -18,6 +18,7 @@ import com.huawei.dmestore.model.StoragePort;
 import com.huawei.dmestore.model.Volume;
 import com.huawei.dmestore.model.VolumeListRestponse;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -36,7 +37,7 @@ public interface DmeStorageService {
      * @return List
      * @throws DmeException when error
      */
-    List<Storage> getStorages() throws DmeException;
+    List<Storage> getStorages(String flag) throws DmeException;
 
     /**
      * get storage detail
@@ -65,7 +66,7 @@ public interface DmeStorageService {
      * @return List
      * @throws DmeException when error
      */
-    List<LogicPorts> getLogicPorts(String storageId,String supportProtocol) throws DmeException;
+    List<LogicPorts> getLogicPorts(String storageId,String supportProtocol,String flag) throws DmeException;
 
     /**
      * list volumes by page
@@ -284,7 +285,7 @@ public interface DmeStorageService {
      * @return String
      * @throws DmeException when error
      */
-    String getStorageByPoolRawId(String poolRawId) throws DmeException;
+    String getStorageByPoolRawId(String poolRawId,String storageId) throws DmeException;
 
     /**
      * list Volume Performance

--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeStorageServiceImpl.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/DmeStorageServiceImpl.java
@@ -3,6 +3,7 @@ package com.huawei.dmestore.services;
 import com.google.gson.*;
 import com.huawei.dmestore.constant.ModelVersionConstants;
 import com.huawei.dmestore.entity.DmeVmwareRelation;
+import com.huawei.dmestore.utils.JsonUtil;
 import com.vmware.vim.binding.vmodl.name;
 
 import com.huawei.dmestore.constant.DmeConstants;
@@ -19,8 +20,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.*;
 
@@ -132,7 +135,7 @@ public class DmeStorageServiceImpl implements DmeStorageService {
     }
 
     @Override
-    public List<Storage> getStorages() throws DmeException {
+    public List<Storage> getStorages(String flag) throws DmeException {
         List<Storage> list = new ArrayList<>();
         try {
             ResponseEntity<String> responseEntity = dmeAccessService.access(DmeConstants.API_STORAGES, HttpMethod.GET,
@@ -200,7 +203,12 @@ public class DmeStorageServiceImpl implements DmeStorageService {
         }
         //剔除版本不支持设备
       List<Storage> storages = excludedNotSupportDevice(list);
-        return storages;
+        //flag 为1表示是创建nfs页面调用
+      if ("1".equalsIgnoreCase(flag)){
+          return excludedDoradoV3(storages);
+      }else {
+          return storages;
+      }
     }
 
     private List<Storage> excludedNotSupportDevice(List<Storage> list) {
@@ -217,7 +225,25 @@ public class DmeStorageServiceImpl implements DmeStorageService {
         }
         return storageList;
     }
-
+    /**
+      * @Description: nfs创建页面设备不支持DoradoV3
+      * @Param @param null
+      * @return @return 
+      * @throws 
+      * @author yc
+      * @Date 2021/4/22 15:04
+     */
+    private List<Storage> excludedDoradoV3(List<Storage> list) {
+        List<Storage> storageList = new ArrayList<>();
+        for (Storage storage:list) {
+            if(!StringUtils.isEmpty(storage)) {
+                if (!ModelVersionConstants.DORADOV3List.contains(StringUtils.trimAllWhitespace(storage.getModel()))) {
+                    storageList.add(storage);
+                }
+            }
+        }
+        return storageList;
+    }
 
     /**
      * get az map
@@ -394,7 +420,7 @@ public class DmeStorageServiceImpl implements DmeStorageService {
         List<StoragePool> resList = new ArrayList<>();
         String url = String.format(DmeConstants.DME_RESOURCE_INSTANCE_LIST, className) + CONDITION;
         String params = ToolUtils.getRequsetParams(STORAGE_DEVICE_ID, replace);
-        List<Storage> storages = getStorages();
+        List<Storage> storages = getStorages(null);
         Map<String, String> ids = new HashMap<>();
         if (storages != null && storages.size() > 0) {
             for (Storage storage : storages) {
@@ -512,7 +538,7 @@ public class DmeStorageServiceImpl implements DmeStorageService {
     }
 
     @Override
-    public List<LogicPorts> getLogicPorts(String storageId,String supportProtocol) throws DmeException {
+    public List<LogicPorts> getLogicPorts(String storageId,String supportProtocol,String flag) throws DmeException {
         List<LogicPorts> resList = new ArrayList<>();
         String url = DmeConstants.API_LOGICPORTS_LIST;
         JsonObject param = null;
@@ -570,7 +596,31 @@ public class DmeStorageServiceImpl implements DmeStorageService {
             LOG.error("list bandports error", e);
             throw new DmeException(CODE_503, e.getMessage());
         }
-        return resList;
+        if("1".equalsIgnoreCase(flag)){
+            return  filterUnsupportedProtocols(resList);
+        }else {
+            return resList;
+        }
+    }
+    /**
+      * @Description: 创建nfs存储，下拉框只支持NFS、NFS_ADN_CIFS这两种协议的端口。其余全过滤掉，存储详情中的share正常显示。不需要过滤
+      * @Param @param null
+      * @return @return 
+      * @throws 
+      * @author yc
+      * @Date 2021/4/22 15:23
+     */
+    private List<LogicPorts> filterUnsupportedProtocols(List<LogicPorts> resList) {
+        List<LogicPorts> logicports = new ArrayList<>();
+        if(!CollectionUtils.isEmpty(resList)){
+            for (LogicPorts logic:resList) {
+                if ("NFS".equalsIgnoreCase(StringUtils.trimWhitespace(logic.getSupportProtocol()))
+                        || "NFS_AND_CIFS".equalsIgnoreCase(StringUtils.trimWhitespace(logic.getSupportProtocol()))){
+                    logicports.add(logic);
+                }
+            }
+        }
+        return logicports;
     }
 
     @Override
@@ -599,7 +649,7 @@ public class DmeStorageServiceImpl implements DmeStorageService {
                     Volume volume = parseVolume(element);
                     String poolRawId = ToolUtils.jsonToStr(element.get(POOL_RAW_ID));
                     if (poolnamecacheMap.get(poolRawId) == null) {
-                        poolnamecacheMap.put(poolRawId, getStorageByPoolRawId(poolRawId));
+                        poolnamecacheMap.put(poolRawId, getStorageByPoolRawId(poolRawId,storageId));
                     }
                     volume.setStoragePoolName(poolnamecacheMap.get(poolRawId));
                     volumes.add(volume);
@@ -1781,11 +1831,14 @@ public class DmeStorageServiceImpl implements DmeStorageService {
     }
 
     @Override
-    public String getStorageByPoolRawId(String poolRawId) throws DmeException {
+    public String getStorageByPoolRawId(String poolRawId,String storageId) throws DmeException {
         String className = "SYS_StoragePool";
         String poolName = "";
         String url = String.format(DmeConstants.DME_RESOURCE_INSTANCE_LIST, className) + CONDITION;
-        String params = ToolUtils.getRequsetParams(POOL_ID, poolRawId);
+        Map<String,String> map = new HashMap<>();
+        map.put(POOL_ID, poolRawId);
+        map.put(STORAGE_DEVICE_ID,storageId);
+        String params = ToolUtils.getRequsetParams(map,true,true);
         ResponseEntity<String> responseEntity = dmeAccessService.accessByJson(url, HttpMethod.GET, params);
         if (responseEntity.getStatusCodeValue() == HttpStatus.OK.value()) {
             String object = responseEntity.getBody();
@@ -1854,7 +1907,7 @@ public class DmeStorageServiceImpl implements DmeStorageService {
     }
 
     private Storage getStorage(String storageId) throws DmeException {
-        List<Storage> storages = getStorages();
+        List<Storage> storages = getStorages(null);
         if (storages != null && storages.size() > 0) {
             for (Storage storage : storages) {
                 if (storageId.equalsIgnoreCase(storage.getId())) {

--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/NfsOperationServiceImpl.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/NfsOperationServiceImpl.java
@@ -657,7 +657,7 @@ public class NfsOperationServiceImpl implements NfsOperationService {
         Map<String, String> respMap = new HashMap<>();
         String mgmt = "";
         String logicName = "";
-        List<LogicPorts> logicPorts = dmeStorageService.getLogicPorts(storageId,"all");
+        List<LogicPorts> logicPorts = dmeStorageService.getLogicPorts(storageId,"all",null);
         if (logicPorts != null) {
             for (LogicPorts logicPort : logicPorts) {
                 if (logicPort != null && !StringUtils.isEmpty(currentPortId) &&

--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/OverviewServiceImpl.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/OverviewServiceImpl.java
@@ -63,7 +63,7 @@ public class OverviewServiceImpl implements OverviewService {
         int normal = 0;
         int abnormal = 0;
         int total;
-        List<Storage> storages = dmeStorageService.getStorages();
+        List<Storage> storages = dmeStorageService.getStorages(null);
         total = storages.size();
         for (Storage storage : storages) {
             // 运行状态 0-离线 1-正常 2-故障 9-未管理。

--- a/dmestore-service/src/main/java/com/huawei/dmestore/utils/VCSDKUtils.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/utils/VCSDKUtils.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.huawei.dmestore.constant.DmeConstants;
 import com.huawei.dmestore.entity.DmeVmwareRelation;
 import com.huawei.dmestore.entity.VCenterInfo;
+import com.huawei.dmestore.exception.DmeException;
 import com.huawei.dmestore.exception.VcenterException;
 import com.huawei.dmestore.model.UpHostVnicRequestBean;
 import com.huawei.vmware.VcConnectionHelpers;
@@ -2050,7 +2051,7 @@ public class VCSDKUtils {
      * @param mountType mountType
      * @throws VcenterException VcenterException
      **/
-    public void mountNfs(String datastoreobjectid, String hostobjectid, String logicPortIp, String mountType, String shareName) {
+    public void mountNfs(String datastoreobjectid, String hostobjectid, String logicPortIp, String mountType, String shareName) throws DmeException {
         try {
             if (datastoreobjectid == null) {
                 logger.info("param datastore is null");
@@ -2087,6 +2088,7 @@ public class VCSDKUtils {
             logger.info("Rescan datastore after mounting");
         } catch (Exception e) {
             logger.error("vmware mount nfs error:{}", e.getMessage());
+            throw new DmeException(e.getMessage());
         }
     }
 
@@ -2097,7 +2099,7 @@ public class VCSDKUtils {
      * @param hostMo hostMo
      * @param datastoreobjectid datastoreobjectid
      */
-    public void unmountNfsOnHost(DatastoreMo dsmo, HostMo hostMo, String datastoreobjectid) {
+    public void unmountNfsOnHost(DatastoreMo dsmo, HostMo hostMo, String datastoreobjectid) throws Exception {
         try {
             if (dsmo == null) {
                 logger.info("datastore is null");
@@ -2120,10 +2122,12 @@ public class VCSDKUtils {
             logger.info("Rescan datastore after unmounting");
         } catch (Exception e) {
             logger.error("unmount nfs error:{}", e.getMessage());
+            throw new Exception(e.getMessage());
+
         }
     }
 
-    public void unmountNfsOnHost(String dataStoreObjectId, String hostObjId) throws VcenterException {
+    public void unmountNfsOnHost(String dataStoreObjectId, String hostObjId) throws DmeException {
         try {
             if (StringUtils.isEmpty(dataStoreObjectId)) {
                 logger.info("param dataStoreObjectId is null");
@@ -2144,7 +2148,7 @@ public class VCSDKUtils {
             unmountNfsOnHost(dsmo, hostmo, dataStoreObjectId);
         } catch (Exception e) {
             logger.error("unmount nfs On host error:{}", e.getMessage());
-            throw new VcenterException(e.getMessage());
+            throw new DmeException(e.getMessage());
         }
     }
 
@@ -3249,7 +3253,7 @@ public class VCSDKUtils {
     /**
      * 获取主机网卡信息
      *
-     * @param hostObjectId 主机objectid
+     * @param hostObjectIds 主机objectid
      * @param recommendMtu MTU期望值
      * @return String String
      */
@@ -3298,8 +3302,8 @@ public class VCSDKUtils {
     /**
      * 获取主机网卡信息
      *
-     * @param hostObjectId 主机objectid
-     * @param recommendMtu MTU期望值
+     * @param beans 主机objectid
+     * @param recommendValue MTU期望值
      */
     public void updateVirtualNicList(List<UpHostVnicRequestBean> beans, int recommendValue) {
         JsonArray jsonArray = new JsonArray();

--- a/dmestore-service/src/test/java/com/huawei/dmestore/services/DmeNFSAccessServiceImplTest.java
+++ b/dmestore-service/src/test/java/com/huawei/dmestore/services/DmeNFSAccessServiceImplTest.java
@@ -263,7 +263,7 @@ public class DmeNFSAccessServiceImplTest {
         storage.setLocation("321");
         storage.setTotalCapacity(60.0);
         storages.add(storage);
-        when(dmeStorageService.getStorages()).thenReturn(storages);
+        when(dmeStorageService.getStorages(anyString())).thenReturn(storages);
         String resp = "{\n" +
                 "    \"id\": \"string\", \n" +
                 "    \"name\": \"string\", \n" +
@@ -554,7 +554,7 @@ public class DmeNFSAccessServiceImplTest {
     }
 
     @Test
-    public void testUnmountNfs() throws DmeException {
+    public void testUnmountNfs() throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("dataStoreObjectId", "321");
         params.put("hostId", "321");

--- a/dmestore-service/src/test/java/com/huawei/dmestore/services/DmeStorageServiceImplTest.java
+++ b/dmestore-service/src/test/java/com/huawei/dmestore/services/DmeStorageServiceImplTest.java
@@ -111,7 +111,7 @@ public class DmeStorageServiceImplTest {
         reqMap.put("datas", reqList);
         ResponseEntity<String> responseEntity = new ResponseEntity<>(gson.toJson(reqMap), null, HttpStatus.OK);
         when(dmeAccessService.access(anyString(), any(), anyString())).thenReturn(responseEntity);
-        List<Storage> storages = dmeStorageService.getStorages();
+        List<Storage> storages = dmeStorageService.getStorages(null);
         System.out.println(storages);
     }
 
@@ -227,7 +227,7 @@ public class DmeStorageServiceImplTest {
         map.put("logic_ports", list);
         ResponseEntity<String> responseEntity = new ResponseEntity<>(gson.toJson(map), null, HttpStatus.OK);
         when(dmeAccessService.access(anyString(), any(), anyString())).thenReturn(responseEntity);
-        List<LogicPorts> logicPorts = dmeStorageService.getLogicPorts(storageId,"ihuiohjoh");
+        List<LogicPorts> logicPorts = dmeStorageService.getLogicPorts(storageId,"ihuiohjoh",null);
         System.out.println(logicPorts);
 
     }

--- a/dmestore-service/src/test/java/com/huawei/dmestore/services/NfsOperationServiceImplTest.java
+++ b/dmestore-service/src/test/java/com/huawei/dmestore/services/NfsOperationServiceImplTest.java
@@ -154,7 +154,7 @@ public class NfsOperationServiceImplTest {
         logicPorts.setName("test1");
         List<LogicPorts> list4 = new ArrayList<>();
         list4.add(logicPorts);
-        when(dmeStorageService.getLogicPorts(storageId,null)).thenReturn(list4);
+        when(dmeStorageService.getLogicPorts(storageId,null,null)).thenReturn(list4);
         Map<String, String> map4 = new HashMap<>();
         map4.put("urn:vmomi:HostSystem:host-1034:674908e5-ab21-4079-9cb1-596358ee5dd1","192.168.200.13");
         List<Map<String, String>> list5 = new ArrayList<>();

--- a/dmestore-service/src/test/java/com/huawei/dmestore/services/OverviewServiceImplTest.java
+++ b/dmestore-service/src/test/java/com/huawei/dmestore/services/OverviewServiceImplTest.java
@@ -67,7 +67,7 @@ public class OverviewServiceImplTest {
         Storage storage = new Storage();
         List<Storage> storages = new ArrayList<>();
         storages.add(storage);
-        when(dmeStorageService.getStorages()).thenReturn(storages);
+        when(dmeStorageService.getStorages(anyString())).thenReturn(storages);
         overviewService.getStorageNum();
     }
 

--- a/dmestore-service/src/test/java/com/huawei/dmestore/services/VmfsAccessServiceTest.java
+++ b/dmestore-service/src/test/java/com/huawei/dmestore/services/VmfsAccessServiceTest.java
@@ -83,7 +83,7 @@ public class VmfsAccessServiceTest {
         Storage storageObj = new Storage();
         storageObj.setName("Huawei.Storage");
         list.add(storageObj);
-        when(dmeStorageService.getStorages()).thenReturn(list);
+        when(dmeStorageService.getStorages(anyString())).thenReturn(list);
         List<Map<String, Object>> lists = new ArrayList<>();
         Map<String, Object> dsmap = new HashMap<>();
         dsmap.put("objectid", storeObjectId);
@@ -718,7 +718,7 @@ public class VmfsAccessServiceTest {
         storage.setId("112");
         storage.setName("tasts");
         storagemap.add(storage);
-        when(dmeStorageService.getStorages()).thenReturn(storagemap);
+        when(dmeStorageService.getStorages(anyString())).thenReturn(storagemap);
         String listStr
             = "[{\"objectid\": \"11\",\"capacity\": 123123141415,\"freeSpace\": 123123141415,\"uncommitted\": 123123141415,\"name\": \"11\"}]";
         when(vcsdkUtils.getAllVmfsDataStoreInfos(DmeConstants.STORE_TYPE_VMFS)).thenReturn(listStr);


### PR DESCRIPTION
2创建nfs存储，没有过滤dorado v3设备
7。创建nfs存储，没有过滤非NFS、NFS_ADN_CIFS协议的逻辑端口     （下拉框只支持NFS、NFS_ADN_CIFS这两种协议的端口。其余全过滤掉，存储详情中的share正常显示。不需要过滤）
9.Nfs挂载失败，显示成功 （功能问题，给网络条件的逻辑端口。）
10.挂载多个主机，卸载其中一个主机，结果：所有客户端都被删掉了
（share 客户端移除多了）