### PR TITLE
vmfs count 限制和提示

### DIFF
--- a/dmestore-ui/src/main/angular/src/app/app.helpers.ts
+++ b/dmestore-ui/src/main/angular/src/app/app.helpers.ts
@@ -153,6 +153,7 @@ export const regExpCollection = {
   /* shareFsName */
   shareFsName: () => /^[A-Za-z0-9!\s!\\\"#&%\$'\(\)\*\+\-,·.:;<=>\?@\[\]\^_`\{\|\}~ ]{1,}$/,
   // shareFsName: new RegExp(`^[a-zA-Z0-9!\"#&%$'()*+-·.;<=>?@\[\]^_\`{|}~,:\s]*$`),
+  integer:()=>/^[1-9]\d*$/
 };
 
 /**

--- a/dmestore-ui/src/main/angular/src/app/routes/vmfs/add/add.component.html
+++ b/dmestore-ui/src/main/angular/src/app/routes/vmfs/add/add.component.html
@@ -21,7 +21,7 @@
     </span>
   </div>
   <!--Page1 -->
-  <clr-wizard-page #addPageOne [clrWizardPageNextDisabled]="isPageNextDisabled">
+  <clr-wizard-page #addPageOne [clrWizardPageNextDisabled]="checkPageOne()&&isPageNextDisabled">
     <ng-template clrPageTitle>{{'vmfs.datastoreSetting' | translate}}</ng-template> <!-- mandatory -->
 
     <form clrForm #formPageOne="ngForm" [formGroup]="addForm">
@@ -131,7 +131,9 @@
             <clr-icon shape="exclamation-circle" class="is-solid"></clr-icon>{{'vmfs.capacityTips' | translate}}
           </div>
         </clr-control-helper>
-        <clr-control-error>{{'validations.required' | translate}}</clr-control-error>
+        <!-- <clr-control-error>{{'validations.required' | translate}}</clr-control-error> -->
+        <clr-control-error>{{'validations.required' | translate}}：{{'vmfs.capacityTips' | translate}}
+        </clr-control-error>
       </clr-input-container>
 
       <!-- 块大小 -->

--- a/dmestore-ui/src/main/angular/src/app/routes/vmfs/add/add.component.ts
+++ b/dmestore-ui/src/main/angular/src/app/routes/vmfs/add/add.component.ts
@@ -790,6 +790,7 @@ export class AddComponent extends VmfsCommon implements OnInit {
    */
   countBlur() {
     let count = this.form.count;
+    /*
     if (count && count !== null && count !== '') {
       if ((count + '').indexOf('.') !== -1) {
         // 小数
@@ -802,6 +803,14 @@ export class AddComponent extends VmfsCommon implements OnInit {
       count = '';
     }
     this.form.count = count;
+   */
+    /* 且容量必须为单位为G的正整数，数量必须为正整数且不超过100 */
+    const isInteger = regExpCollection.integer().test(count);
+    // console.log("🚀 ~ file: add.component.ts ~ line 810 ~ AddComponent ~ countBlur ~ isInteger", isInteger);
+
+    if (!(isInteger && count > 0 && count <= 100)) {
+      this.form.count = null;
+    }
   }
 
   /**

--- a/dmestore-ui/src/main/angular/src/app/routes/vmfs/list/VmfsCommon.ts
+++ b/dmestore-ui/src/main/angular/src/app/routes/vmfs/list/VmfsCommon.ts
@@ -10,7 +10,7 @@ export class VmfsCommon {
 
   constructor() {
     this.createAddFormAndWatchFormChange();
-    this.checkPageOne = debounce(this.checkPageOne.bind(this), 300);
+    (this.checkPageOne as any) = debounce(this.checkPageOne.bind(this), 300);
   }
 
   handlerValueChanges(addForm) {
@@ -50,6 +50,11 @@ export class VmfsCommon {
     this.form.spaceReclamationPriority = this.addForm.value.spaceReclamationPriority;
     this.form.chooseDevice = this.addForm.value.chooseDevice;
 
+    try {
+      /* 数量 */
+      // console.log("countBlur");
+      (this as any).countBlur();
+    } catch (error) {}
     const isname = !!this.form.name;
     const isvolumeName = !!this.form.volumeName;
     const isversion = !!this.form.version;
@@ -59,7 +64,7 @@ export class VmfsCommon {
     const isspaceReclamationGranularity = !!this.form.spaceReclamationGranularity;
     const isspaceReclamationPriority = !!this.form.spaceReclamationPriority;
     const ischooseDevice = !!this.form.chooseDevice;
-
+/* 
     console.log(
       'isname',
       isname,
@@ -80,7 +85,7 @@ export class VmfsCommon {
       'ischooseDevice',
       ischooseDevice
     );
-
+ */
     this.isPageNextDisabled = !(
       isname &&
       isvolumeName &&
@@ -93,6 +98,7 @@ export class VmfsCommon {
       ischooseDevice
     );
     this.cdr.detectChanges();
+    return true;
   }
 
   createAddFormAndWatchFormChange() {

--- a/dmestore-ui/src/main/angular/src/app/routes/vmfs/list/list.component.html
+++ b/dmestore-ui/src/main/angular/src/app/routes/vmfs/list/list.component.html
@@ -317,8 +317,13 @@
 
     <!--Page1 -->
     <!-- vmfs 数据存储 添加 -->
-    <clr-wizard-page #addPageOne [clrWizardPageNextDisabled]="isPageNextDisabled">
+    <clr-wizard-page #addPageOne [clrWizardPageNextDisabled]="checkPageOne()&&isPageNextDisabled">
       <ng-template clrPageTitle>{{'vmfs.datastoreSetting' | translate}}</ng-template> <!-- mandatory -->
+      <!--       <pre>
+        {{checkPageOne()}}
+        {{print(form)}}
+      </pre>
+ -->
       <form clrForm [formGroup]="addForm" #formPageOne="ngForm">
         <!--数据存储名称 -->
         <clr-input-container>
@@ -424,8 +429,7 @@
               {{'vmfs.capacityTips' | translate}}
             </div>
           </clr-control-helper>
-          <clr-control-error>{{'validations.required' | translate}}：{{'vmfs.capacityTips' | translate}}
-          </clr-control-error>
+          <clr-control-error>{{'validations.required' | translate}}：{{'vmfs.capacityTips' | translate}} </clr-control-error>
         </clr-input-container>
         <!-- 块大小 -->
         <clr-select-container class="selectClass" *ngIf="isShowInput">

--- a/dmestore-ui/src/main/angular/src/app/routes/vmfs/list/list.component.ts
+++ b/dmestore-ui/src/main/angular/src/app/routes/vmfs/list/list.component.ts
@@ -1832,7 +1832,7 @@ wwn: "67c1cf110058934511ba6e5a00000344"
    */
   countBlur() {
     let count = this.form.count;
-    if (count && count !== null && count !== '') {
+    /*     if (count && count !== null && count !== '') {
       if ((count + '').indexOf('.') !== -1) {
         // 小数
         count = '';
@@ -1844,6 +1844,14 @@ wwn: "67c1cf110058934511ba6e5a00000344"
       count = '';
     }
     this.form.count = count;
+ */
+
+    /* 且容量必须为单位为G的正整数，数量必须为正整数且不超过100 */
+    const isInteger = regExpCollection.integer().test(count);
+
+    if (!(isInteger && count > 0 && count <= 100)) {
+      this.form.count = null;
+    }
   }
 
   /**

--- a/dmestore-ui/src/main/angular/src/assets/i18n/en-US.json
+++ b/dmestore-ui/src/main/angular/src/assets/i18n/en-US.json
@@ -267,7 +267,7 @@
     "startTime": "Start Time",
     "endTime": "End Time",
     "timeInputTips": "Please enter start-end time！",
-    "capacityTips": "If the version is VMFS5, the minimum capacity is 1G, if the version is VMFS6, the minimum capacity is 2G, and the capacity must be a positive integer in G, and the quantity must be a positive integer!",
+    "capacityTips": "If the version is VMFS5, the minimum capacity is 1G, if the version is VMFS6, the minimum capacity is 2G, and the capacity must be a positive integer in G, and the quantity must be a positive integer and must lower than 100!",
     "serviceLevelCantBeNull": "The DME Storage Strategy is a must, and you can only choose the DME Storage Strategy whose capacity is not 0!",
     "expandTips": "Expansion capacity can only be a positive integer of GB",
     "expandTipsMax": "After expansion, the total capacity cannot exceed 256TB.",

--- a/dmestore-ui/src/main/angular/src/assets/i18n/zh-CN.json
+++ b/dmestore-ui/src/main/angular/src/assets/i18n/zh-CN.json
@@ -267,7 +267,7 @@
     "startTime": "开始时间",
     "endTime": "结束时间",
     "timeInputTips": "请输入开始-结束时间！",
-    "capacityTips": "若版本为VMFS5则容量最小值为1G，若版本为VMFS6则容量最小值为2G，且容量必须为单位为G的正整数，数量必须为正整数！",
+    "capacityTips": "若版本为VMFS5则容量最小值为1G，若版本为VMFS6则容量最小值为2G，且容量必须为单位为G的正整数，数量必须为正整数且不超过100",
     "serviceLevelCantBeNull": "DME存储策略是必选项，且只能选择容量不为0的DME存储策略！",
     "expandTips": "扩容容量只能单位为GB的正整数。",
     "expandTipsMax": "扩容后总容量不能超过256TB。",


### PR DESCRIPTION
若版本为VMFS5则容量最小值为1G，若版本为VMFS6则容量最小值为2G，且容量必须为单位为G的正整数，数量必须为正整数且不超过100